### PR TITLE
Update .clang-format and Graph_memory.hpp

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,89 +1,89 @@
 ---
 Language:        Cpp
-# BasedOnStyle:  LLVM
+BasedOnStyle:  LLVM
 AccessModifierOffset: -2
-AlignAfterOpenBracket: Align
-AlignArrayOfStructures: None
-AlignConsecutiveMacros: None
-AlignConsecutiveAssignments: None
-AlignConsecutiveBitFields: None
-AlignConsecutiveDeclarations: None
-AlignEscapedNewlines: Right
-AlignOperands:   Align
-AlignTrailingComments: true
-AllowAllArgumentsOnNextLine: true
-AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortEnumsOnASingleLine: true
-AllowShortBlocksOnASingleLine: Never
-AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: All
-AllowShortLambdasOnASingleLine: All
-AllowShortIfStatementsOnASingleLine: Never
-AllowShortLoopsOnASingleLine: false
-AlwaysBreakAfterDefinitionReturnType: None
-AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: MultiLine
+#AlignAfterOpenBracket: None    ####I suppose we don't have the functions with so much args
+#AlignArrayOfStructures: None   
+#AlignConsecutiveMacros: None  
+#AlignConsecutiveAssignments: None 
+#AlignConsecutiveBitFields: None 
+#AlignConsecutiveDeclarations: None 
+AlignEscapedNewlines: DontAlign ###changed
+AlignOperands:   Align 
+#AlignTrailingComments: None
+#AllowAllArgumentsOnNextLine: None
+#AllowAllParametersOfDeclarationOnNextLine: None
+#AllowShortEnumsOnASingleLine: None
+AllowShortBlocksOnASingleLine: Never 
+AllowShortCaseLabelsOnASingleLine: false 
+AllowShortFunctionsOnASingleLine: InlineOnly ###changed
+#AllowShortLambdasOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never 
+AllowShortLoopsOnASingleLine: false 
+#AlwaysBreakAfterDefinitionReturnType: None
+#AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false 
+AlwaysBreakTemplateDeclarations: Yes ###changed
 AttributeMacros:
   - __capability
-BinPackArguments: true
-BinPackParameters: true
-BraceWrapping:
-  AfterCaseLabel:  false
-  AfterClass:      false
-  AfterControlStatement: Never
-  AfterEnum:       false
-  AfterFunction:   false
-  AfterNamespace:  false
-  AfterObjCDeclaration: false
-  AfterStruct:     false
-  AfterUnion:      false
-  AfterExternBlock: false
-  BeforeCatch:     false
-  BeforeElse:      false
-  BeforeLambdaBody: false
-  BeforeWhile:     false
-  IndentBraces:    false
-  SplitEmptyFunction: true
-  SplitEmptyRecord: true
-  SplitEmptyNamespace: true
-BreakBeforeBinaryOperators: None
-BreakBeforeConceptDeclarations: true
+#BinPackArguments: true
+#BinPackParameters: true
+# BraceWrapping:
+#   AfterCaseLabel:  false
+#   AfterClass:      false
+#   AfterControlStatement: Never
+#   AfterEnum:       false
+#   AfterFunction:   false
+#   AfterNamespace:  false
+#   AfterObjCDeclaration: false
+#   AfterStruct:     false
+#   AfterUnion:      false
+#   AfterExternBlock: false
+#   BeforeCatch:     true ###changed
+#   BeforeElse:      true ###changed
+#   BeforeLambdaBody: false
+#   BeforeWhile:     false
+#   IndentBraces:    false
+#   SplitEmptyFunction: false ###changed
+#   SplitEmptyRecord: false ###changed
+#   SplitEmptyNamespace: true ###changed
+#BreakBeforeBinaryOperators: None
+#BreakBeforeConceptDeclarations: true
 BreakBeforeBraces: Attach
-BreakBeforeInheritanceComma: false
-BreakInheritanceList: BeforeColon
-BreakBeforeTernaryOperators: true
-BreakConstructorInitializersBeforeComma: false
-BreakConstructorInitializers: BeforeColon
-BreakAfterJavaFieldAnnotations: false
+#BreakBeforeInheritanceComma: false
+BreakInheritanceList: AfterColon ###changed
+#BreakBeforeTernaryOperators: true
+#BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: AfterColon ###changed
+#BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
 ColumnLimit:     80
-CommentPragmas:  '^ IWYU pragma:'
+#CommentPragmas:  '^ IWYU pragma:'
 QualifierAlignment: Leave
-CompactNamespaces: false
-ConstructorInitializerIndentWidth: 4
+#CompactNamespaces: false
+#ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
-Cpp11BracedListStyle: true
+#Cpp11BracedListStyle: true
 DeriveLineEnding: true
 DerivePointerAlignment: false
 DisableFormat:   false
-EmptyLineAfterAccessModifier: Never
-EmptyLineBeforeAccessModifier: LogicalBlock
-ExperimentalAutoDetectBinPacking: false
-PackConstructorInitializers: BinPack
+#EmptyLineAfterAccessModifier: Never
+#EmptyLineBeforeAccessModifier: LogicalBlock
+#ExperimentalAutoDetectBinPacking: false
+#PackConstructorInitializers: BinPack
 BasedOnStyle:    ''
-ConstructorInitializerAllOnOneLineOrOnePerLine: false
-AllowAllConstructorInitializersOnNextLine: true
+#ConstructorInitializerAllOnOneLineOrOnePerLine: false
+#AllowAllConstructorInitializersOnNextLine: true
 FixNamespaceComments: true
-ForEachMacros:
-  - foreach
-  - Q_FOREACH
-  - BOOST_FOREACH
-IfMacros:
-  - KJ_IF_MAYBE
-IncludeBlocks:   Preserve
+# ForEachMacros:
+#   - foreach
+#   - Q_FOREACH
+#   - BOOST_FOREACH
+# IfMacros:
+#   - KJ_IF_MAYBE
+IncludeBlocks:   Regroup
 IncludeCategories:
-  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'     
     Priority:        2
     SortPriority:    0
     CaseSensitive:   false
@@ -94,32 +94,33 @@ IncludeCategories:
   - Regex:           '.*'
     Priority:        1
     SortPriority:    0
-    CaseSensitive:   false
+    CaseSensitive:   false                                      ###Headers???
 IncludeIsMainRegex: '(Test)?$'
 IncludeIsMainSourceRegex: ''
 IndentAccessModifiers: false
-IndentCaseLabels: false
-IndentCaseBlocks: false
-IndentGotoLabels: true
-IndentPPDirectives: None
-IndentExternBlock: AfterExternBlock
-IndentRequires:  false
+IndentCaseLabels: true ###changed
+#IndentCaseBlocks: false
+#IndentGotoLabels: true
+#IndentPPDirectives: None
+IndentExternBlock: Indent ###changed
+#IndentRequires:  false
 IndentWidth:     2
-IndentWrappedFunctionNames: false
-InsertTrailingCommas: None
-JavaScriptQuotes: Leave
-JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: true
-LambdaBodyIndentation: Signature
+#IndentWrappedFunctionNames: false
+#InsertTrailingCommas: None
+#JavaScriptQuotes: Leave
+#JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false ###changed
+LineEnding: LF
+#LambdaBodyIndentation: OuterScope
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
-NamespaceIndentation: None
-ObjCBinPackProtocolList: Auto
-ObjCBlockIndentWidth: 2
-ObjCBreakBeforeNestedBlockParam: true
-ObjCSpaceAfterProperty: false
-ObjCSpaceBeforeProtocolList: true
+#NamespaceIndentation: None
+#ObjCBinPackProtocolList: Auto
+#ObjCBlockIndentWidth: 2
+# ObjCBreakBeforeNestedBlockParam: true
+# ObjCSpaceAfterProperty: false
+# ObjCSpaceBeforeProtocolList: true
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
@@ -129,50 +130,50 @@ PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
-PenaltyIndentedWhitespace: 0
-PointerAlignment: Right
+PenaltyIndentedWhitespace: 0                ########????????
+#PointerAlignment: Right
 PPIndentWidth:   -1
-ReferenceAlignment: Pointer
-ReflowComments:  true
-RemoveBracesLLVM: false
+#ReferenceAlignment: Pointer
+#ReflowComments:  true
+#RemoveBracesLLVM: false
 SeparateDefinitionBlocks: Leave
-ShortNamespaceLines: 1
-SortIncludes:    CaseSensitive
-SortJavaStaticImport: Before
-SortUsingDeclarations: true
+#ShortNamespaceLines: 1
+#SortIncludes:    CaseSensitive
+#SortJavaStaticImport: Before
+#SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeCaseColon: false
-SpaceBeforeCpp11BracedList: false
-SpaceBeforeCtorInitializerColon: true
-SpaceBeforeInheritanceColon: true
-SpaceBeforeParens: ControlStatements
+#SpaceBeforeCpp11BracedList: false
+#SpaceBeforeCtorInitializerColon: true
+#SpaceBeforeInheritanceColon: true
+#SpaceBeforeParens: ControlStatements
 SpaceBeforeParensOptions:
   AfterControlStatements: true
-  AfterForeachMacros: true
+  #AfterForeachMacros: true
   AfterFunctionDefinitionName: false
   AfterFunctionDeclarationName: false
-  AfterIfMacros:   true
-  AfterOverloadedOperator: false
-  BeforeNonEmptyParentheses: false
-SpaceAroundPointerQualifiers: Default
-SpaceBeforeRangeBasedForLoopColon: true
-SpaceInEmptyBlock: false
+  #AfterIfMacros:   true
+  #AfterOverloadedOperator: false
+  #BeforeNonEmptyParentheses: false
+#SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: false
+#SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 1
+#SpacesBeforeTrailingComments: 1
 SpacesInAngles:  Never
 SpacesInConditionalStatement: false
-SpacesInContainerLiterals: true
+#SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
-SpacesInLineCommentPrefix:
-  Minimum:         1
-  Maximum:         -1
+# SpacesInLineCommentPrefix:
+#   Minimum:         1
+#   Maximum:         -1
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 SpaceBeforeSquareBrackets: false
-BitFieldColonSpacing: Both
+#BitFieldColonSpacing: Both
 Standard:        Latest
 StatementAttributeLikeMacros:
   - Q_EMIT

--- a/.clang-format
+++ b/.clang-format
@@ -1,197 +1,192 @@
 ---
-Language: Cpp
-BasedOnStyle: Google
+Language:        Cpp
+# BasedOnStyle:  LLVM
 AccessModifierOffset: -2
-AlignAfterOpenBracket: BlockIndent
-AlignConsecutiveMacros:
-  Enabled: true
-  AcrossEmptyLines: true
-  AcrossComments: true
-AlignConsecutiveAssignments:
-  Enabled: true
-  AcrossEmptyLines: true
-  AcrossComments: true
-  AlignCompound: true
-  PadOperators: true
-AlignConsecutiveBitFields:
-  Enabled: true
-  AcrossEmptyLines: true
-  AcrossComments: true
-AlignConsecutiveDeclarations:
-  Enabled: true
-  AcrossEmptyLines: true
-  AcrossComments: true
-  #AlignFunctionPointers: true
-  PadOperators: true
-AlignEscapedNewlines: DontAlign
-AlignOperands: AlignAfterOperator
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveMacros: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: Right
+AlignOperands:   Align
 AlignTrailingComments: true
-#  Kind: true
-#  OverEmptyLines: 1
 AllowAllArgumentsOnNextLine: true
-AllowAllParametersOfDeclarationOnNextLine: false
-AllowShortEnumsOnASingleLine: false
-AllowShortBlocksOnASingleLine: Empty
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: Inline
+AllowShortFunctionsOnASingleLine: All
 AllowShortLambdasOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
-AlwaysBreakBeforeMultilineStrings: true
-BinPackArguments: false
-BinPackParameters: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
 BraceWrapping:
-  AfterCaseLabel: false
-  AfterClass: true
-  AfterControlStatement: MultiLine
-  AfterEnum: true
-  AfterFunction: true
-  AfterNamespace: true
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
   AfterObjCDeclaration: false
-  AfterStruct: true
-  AfterUnion: true
-  AfterExternBlock: true
-  BeforeCatch: false
-  BeforeElse: false
-  BeforeLambdaBody: true
-  BeforeWhile: false
-  IndentBraces: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
   SplitEmptyFunction: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
-# BreakAfterReturnType: None
-BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: true
 BreakBeforeBraces: Attach
-# BreakBeforeInheritanceComma: true
-BreakInheritanceList: AfterColon
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
 BreakBeforeTernaryOperators: true
-BreakConstructorInitializers: AfterColon
-BreakAfterJavaFieldAnnotations: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
-# BreakTemplateDeclarations: Yes
-ColumnLimit: 80
-CommentPragmas: '^ IWYU pragma:'
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Leave
 CompactNamespaces: false
-ConstructorInitializerIndentWidth: 2
+ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
+DeriveLineEnding: true
 DerivePointerAlignment: false
-DisableFormat: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
 ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: BinPack
+BasedOnStyle:    ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowAllConstructorInitializersOnNextLine: true
 FixNamespaceComments: true
 ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
-IncludeBlocks: Regroup
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Preserve
 IncludeCategories:
-  # Standard library headers come before anything else
-  - Regex: '^<[a-z_]+>'
-    Priority: -1
-  - Regex: '^<.+\.h(pp)?>'
-    Priority: 1
-  - Regex: '^<.*'
-    Priority: 2
-  - Regex: '.*'
-    Priority: 3
-IncludeIsMainRegex: ''
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
 IncludeIsMainSourceRegex: ''
-IndentCaseLabels: true
+IndentAccessModifiers: false
+IndentCaseLabels: false
 IndentCaseBlocks: false
 IndentGotoLabels: true
-IndentPPDirectives: AfterHash
-IndentExternBlock: Indent
-IndentWidth: 2
-IndentWrappedFunctionNames: true
-InsertTrailingCommas: Wrapped
-JavaScriptQuotes: Double
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequires:  false
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: false
-#LineEnding: LF
+KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: Signature
 MacroBlockBegin: ''
-MacroBlockEnd: ''
+MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
-NamespaceIndentation: Inner
-ObjCBinPackProtocolList: Never
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 2
 ObjCBreakBeforeNestedBlockParam: true
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
-PackConstructorInitializers: NextLine
 PenaltyBreakAssignment: 2
-PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
 PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 200
-PointerAlignment: Left
-RawStringFormats:
-  - Language: Cpp
-    Delimiters:
-      - cc
-      - CC
-      - cpp
-      - Cpp
-      - CPP
-      - 'c++'
-      - 'C++'
-    CanonicalDelimiter: ''
-    BasedOnStyle: google
-  - Language: TextProto
-    Delimiters:
-      - pb
-      - PB
-      - proto
-      - PROTO
-    EnclosingFunctions:
-      - EqualsProto
-      - EquivToProto
-      - PARSE_PARTIAL_TEXT_PROTO
-      - PARSE_TEST_PROTO
-      - PARSE_TEXT_PROTO
-      - ParseTextOrDie
-      - ParseTextProtoOrDie
-      - ParseTestProto
-      - ParsePartialTestProto
-    CanonicalDelimiter: ''
-    BasedOnStyle: google
-ReflowComments: true
-SortIncludes: CaseInsensitive
-SortUsingDeclarations: true #LexicographicNumeric
+PenaltyReturnTypeOnItsOwnLine: 60
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Right
+PPIndentWidth:   -1
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
-SpaceAfterTemplateKeyword: false
+SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
-SpaceBeforeCpp11BracedList: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
-SpaceBeforeParens: ControlStatementsExceptForEachMacros
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
 SpaceBeforeRangeBasedForLoopColon: true
 SpaceInEmptyBlock: false
-SpacesBeforeTrailingComments: 2
-SpacesInAngles: Never
-SpacesInContainerLiterals: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
 SpacesInParentheses: false
-#SpacesInParens: Custom
-#SpacesInParensOptions:
-#  InConditionalStatements: false
-#  InCStyleCasts: false
-#  InEmptyParentheses: false
-#  Other: false  
 SpacesInSquareBrackets: false
 SpaceBeforeSquareBrackets: false
-Standard:  c++17
+BitFieldColonSpacing: Both
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
 StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION
-TabWidth: 8
-UseCRLF: false
-UseTab: Never
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
 WhitespaceSensitiveMacros:
   - STRINGIZE
   - PP_STRINGIZE
   - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
 ...
+

--- a/.clang-format
+++ b/.clang-format
@@ -1,11 +1,11 @@
 ---
 Language:        Cpp
-BasedOnStyle:  LLVM
+BasedOnStyle:  None          ####We can't add a style, because of adding default conditions for the style
 AccessModifierOffset: -2
 #AlignAfterOpenBracket: None    ####I suppose we don't have the functions with so much args
 #AlignArrayOfStructures: None   
 #AlignConsecutiveMacros: None  
-#AlignConsecutiveAssignments: None 
+AlignConsecutiveAssignments: false
 #AlignConsecutiveBitFields: None 
 #AlignConsecutiveDeclarations: None 
 AlignEscapedNewlines: DontAlign ###changed
@@ -28,7 +28,7 @@ AttributeMacros:
   - __capability
 #BinPackArguments: true
 #BinPackParameters: true
-# BraceWrapping:
+BraceWrapping:
 #   AfterCaseLabel:  false
 #   AfterClass:      false
 #   AfterControlStatement: Never
@@ -66,12 +66,12 @@ ContinuationIndentWidth: 4
 #Cpp11BracedListStyle: true
 DeriveLineEnding: true
 DerivePointerAlignment: false
-DisableFormat:   false
+DisableFormat:   false             ##########ERROR
 #EmptyLineAfterAccessModifier: Never
 #EmptyLineBeforeAccessModifier: LogicalBlock
 #ExperimentalAutoDetectBinPacking: false
 #PackConstructorInitializers: BinPack
-BasedOnStyle:    ''
+BasedOnStyle: None                    ########ERROR
 #ConstructorInitializerAllOnOneLineOrOnePerLine: false
 #AllowAllConstructorInitializersOnNextLine: true
 FixNamespaceComments: true
@@ -109,8 +109,7 @@ IndentWidth:     2
 #InsertTrailingCommas: None
 #JavaScriptQuotes: Leave
 #JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: false ###changed
-LineEnding: LF
+KeepEmptyLinesAtTheStartOfBlocks: true ###changed
 #LambdaBodyIndentation: OuterScope
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
@@ -143,7 +142,7 @@ SeparateDefinitionBlocks: Leave
 #SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
-SpaceAfterTemplateKeyword: true
+SpaceAfterTemplateKeyword: false
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeCaseColon: false
 #SpaceBeforeCpp11BracedList: false

--- a/include/CircuitGenGraph/GraphMemory.hpp
+++ b/include/CircuitGenGraph/GraphMemory.hpp
@@ -11,9 +11,10 @@
 
 typedef unsigned char bytea;
 
-
 /// @author Fuuulkrum7
 struct MultiLinearAllocator {
+  // clang-format off
+
   MultiLinearAllocator(size_t buf_size, size_t chunk_size)
       : buf_size(buf_size)
       , chunk_size(chunk_size) {
@@ -23,6 +24,8 @@ struct MultiLinearAllocator {
     blocks.push_back(offset = new bytea[buf_size]);
   }
 
+  // clang-format on
+
   ~MultiLinearAllocator() {
     for (auto block: blocks) {
       delete[] block;
@@ -30,7 +33,7 @@ struct MultiLinearAllocator {
   }
 
   template<typename T>
-  T* allocate() {
+  T *allocate() {
     bytea *current = offset;
     offset += sizeof(T);
     align<T>();
@@ -44,7 +47,7 @@ struct MultiLinearAllocator {
       buf_size = chunk_size;
       return allocate<T>();
     }
-    return reinterpret_cast<T*>(current);
+    return reinterpret_cast<T *>(current);
   }
 
   void deallocate() {}
@@ -60,7 +63,7 @@ private:
 
 private:
   std::vector<bytea *> blocks;
-  bytea* offset;
+  bytea *offset;
   size_t buf_size;
   size_t chunk_size;
 };
@@ -68,6 +71,8 @@ private:
 /// @author Fuuulkrum7
 class GraphMemory {
 public:
+  // clang-format off
+
   /// @param buf_size size, which would be used for memory buffer reserve.
   /// By default we allocate memory for 1024 base vertices. Size of one vertex
   /// is supposed to be 80 bytes by default.
@@ -81,21 +86,23 @@ public:
       , d_strings {&d_stringMemory}
   {}
 
-  GraphMemory& operator=(GraphMemory&& other)      = delete;
-  GraphMemory(GraphMemory&& other)                 = delete;
-  GraphMemory& operator=(const GraphMemory& other) = delete;
-  GraphMemory(const GraphMemory& other)            = delete;
+  // clang-format on
+
+  GraphMemory &operator=(GraphMemory &&other) = delete;
+  GraphMemory(GraphMemory &&other) = delete;
+  GraphMemory &operator=(const GraphMemory &other) = delete;
+  GraphMemory(const GraphMemory &other) = delete;
 
   std::string_view internalize(std::string_view s) {
     return *d_strings.emplace(s).first;
   }
 
-  std::string_view internalize(const std::string& s) {
+  std::string_view internalize(const std::string &s) {
     return *d_strings.emplace(s).first;
   }
 
   template<typename T>
-  T* allocate() {
+  T *allocate() {
     return d_vertexMemory.allocate<T>();
   }
 
@@ -103,5 +110,5 @@ private:
   MultiLinearAllocator d_vertexMemory;
 
   std::pmr::monotonic_buffer_resource d_stringMemory;
-  std::pmr::set<std::string>          d_strings;
+  std::pmr::set<std::string> d_strings;
 };


### PR DESCRIPTION
I figured out how to work with clang-format with many details like the fact that we can't use fully custom formatting. We can use only predefined styles with changes in config and if we don't choose a style, the config will choose the LLVM style as a default anyway.
- so I went through the formatting keys and left only the most important for our code style
- the lint's not drawing attention to the bad format now
- Graph_Memory.hpp is updated to ignore the strictest rules by automatically chosen LLVM style in .clang-format